### PR TITLE
Feature/mariadb annotate rows event

### DIFF
--- a/examples/mariadb_gtid/read_event.py
+++ b/examples/mariadb_gtid/read_event.py
@@ -6,7 +6,7 @@ from pymysqlreplication.row_event import WriteRowsEvent, UpdateRowsEvent, Delete
 
 MARIADB_SETTINGS = {
     "host": "127.0.0.1",
-    "port": 4306,
+    "port": 3306,
     "user": "replication_user",
     "passwd": "secret123passwd",
 }

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1027,7 +1027,10 @@ class TestMariadbBinlogStreaReader(base.PyMySQLReplicationMariaDbTestCase):
             )
         
         event = self.stream.fetchone()
+        #Check event type 160,MariadbAnnotateRowsEvent
         self.assertEqual(event.event_type,160)
+        #Check self.sql_statement
+        self.assertEqual(event.sql_statement,b"INSERT INTO test (id, data) VALUES(1, 'Hello')")
         self.assertIsInstance(event,MariadbAnnotateRowsEvent)
         
 


### PR DESCRIPTION
* 테스트 코드 필드 값에 대한 assert 구문 추가
* 기존` examples/mariadb_gtid/read_event.py` 파일  포트 번호 복구