### PR TITLE
Fixed  mariadb gtid list event

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
 version: '3.2'
 services:
-  percona-5.7:
-    image: percona:5.7
-    environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: true
-    ports:
-      - 3306:3306
-    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates
+#   percona-5.7:
+#     image: percona:5.7
+#     environment:
+#       MYSQL_ALLOW_EMPTY_PASSWORD: true
+#     ports:
+#       - 3306:3306
+#     command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates
 
-  percona-5.7-ctl:
-    image: percona:5.7
-    environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: true
-    ports:
-      - 3307:3307
-    command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates -P 3307
+#   percona-5.7-ctl:
+#     image: percona:5.7
+#     environment:
+#       MYSQL_ALLOW_EMPTY_PASSWORD: true
+#     ports:
+#       - 3307:3307
+#     command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates -P 3307
 
   mariadb-10.6:
     image: mariadb:10.6
@@ -28,3 +28,4 @@ services:
       --log-bin=master-bin
       --binlog-format=row
       --log-slave-updates=on
+      --max_binlog_size=2048

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -115,7 +115,7 @@ class MariadbGtidListEvent(BinLogEvent):
             def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
                 super(MariadbGtidObejct, self).__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
                 self.domain_id = self.packet.read_uint32()
-                self.server_id = self.packet.server_id
+                self.server_id = self.packet.read_uint32()
                 self.gtid_seq_no = self.packet.read_uint64()
                 self.gtid = "%d-%d-%d" % (self.domain_id, self.server_id, self.gtid_seq_no)
 

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -112,8 +112,8 @@ class MariadbGtidListEvent(BinLogEvent):
             """
             Information class of elements in GTID list
             """
-            def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-                super(MariadbGtidObejct, self).__init__(from_packet, event_size, table_map, ctl_connection, **kwargs)
+            def __init__(self, from_packet):
+                self.packet = from_packet
                 self.domain_id = self.packet.read_uint32()
                 self.server_id = self.packet.read_uint32()
                 self.gtid_seq_no = self.packet.read_uint64()
@@ -121,7 +121,7 @@ class MariadbGtidListEvent(BinLogEvent):
 
 
         self.gtid_length = self.packet.read_uint32()
-        self.gtid_list = [MariadbGtidObejct(from_packet, event_size, table_map, ctl_connection, **kwargs) for i in range(self.gtid_length)]
+        self.gtid_list = [MariadbGtidObejct(self.packet) for i in range(self.gtid_length)]
 
         
     def _dump(self):

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1005,19 +1005,28 @@ class GtidTests(unittest.TestCase):
 class TestMariadbBinlogStreaReader(base.PyMySQLReplicationMariaDbTestCase):
         
     def test_gtid_list_event(self):
-        event = self.stream.fetchone()
-        self.assertEqual(event.position, 4)  
+
+        query = "CREATE TABLE test (id INT NOT NULL AUTO_INCREMENT, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))"
+        self.execute(query)
+        query3 = "INSERT INTO test (data) VALUES('a')"
+        for i in range(0, 20):
+            self.execute(query3)
+            query = "COMMIT;"
+            self.execute(query)
         
-        #FormatDescriptionEvent
+        event = self.stream.fetchone()
+        self.assertEqual(event.event_type,4)
+        # File Description
         event = self.stream.fetchone()
         self.assertEqual(event.event_type,15)
-        self.assertIsInstance(event,FormatDescriptionEvent)
-
-        #MariadbAnnotateRowsEvent
+        # GTID List event
         event = self.stream.fetchone()
         self.assertEqual(event.event_type,163)
         self.assertIsInstance(event,MariadbGtidListEvent)
+        self.assertEqual(event.gtid_list[0].gtid,"0-1-16")
 
+       
+            
 if __name__ == "__main__":
     import unittest
     unittest.main()


### PR DESCRIPTION
`examples/mariadb_gtid/read_event.py`  파일의 실행시켜보니 아래와 같은 발생하네요!

gtid_list_event 패킷에서 auto_position 설정이 GTID(값이 '0-1-1' 입니다)로 되어있을 경우 gtid_list_event가 한번 더 불러와지는 현상이 있네요.. 도움을 좀 구하겠습니다...(심지어 시간도 이상하게 들어오고 log pos도 event하나를 통째로 띄어넘네요....)

![image](https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/assets/65060314/b9aed988-e6be-4bc8-b4f9-6bdf4e40683c)
![image](https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/assets/65060314/4785771f-c5ca-42f7-8476-57ce5deccb13)
