### PR TITLE
Feature/mariadb binlog checkpoint event test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,16 @@ services:
     ports:
       - 3307:3307
     command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates -P 3307
+
+    mariadb-10.6:
+    image: mariadb:10.6
+    environment:
+      MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1
+    ports:
+      - "3308:3306"
+    command: |
+      --server-id=1
+      --default-authentication-plugin=mysql_native_password
+      --log-bin=master-bin
+      --binlog-format=row
+      --log-slave-updates=on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - 3307:3307
     command: mysqld --log-bin=mysql-bin.log --server-id 1 --binlog-format=row --gtid_mode=on --enforce-gtid-consistency=on --log_slave_updates -P 3307
 
-    mariadb-10.6:
+  mariadb-10.6:
     image: mariadb:10.6
     environment:
       MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 1

--- a/examples/mariadb_gtid/read_event.py
+++ b/examples/mariadb_gtid/read_event.py
@@ -1,7 +1,7 @@
 import pymysql
 
 from pymysqlreplication import BinLogStreamReader, gtid
-from pymysqlreplication.event import GtidEvent, RotateEvent, MariadbGtidEvent, QueryEvent
+from pymysqlreplication.event import GtidEvent, RotateEvent, MariadbGtidEvent, QueryEvent, MariadbBinLogCheckPointEvent
 from pymysqlreplication.row_event import WriteRowsEvent, UpdateRowsEvent, DeleteRowsEvent
 
 MARIADB_SETTINGS = {
@@ -62,6 +62,7 @@ if __name__ == "__main__":
         blocking=False,
         only_events=[
             MariadbGtidEvent,
+            MariadbBinLogCheckPointEvent,
             RotateEvent,
             WriteRowsEvent,
             UpdateRowsEvent,

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -14,7 +14,7 @@ from .event import (
     QueryEvent, RotateEvent, FormatDescriptionEvent,
     XidEvent, GtidEvent, StopEvent, XAPrepareEvent,
     BeginLoadQueryEvent, ExecuteLoadQueryEvent,
-    HeartbeatLogEvent, NotImplementedEvent, MariadbGtidEvent)
+    HeartbeatLogEvent, NotImplementedEvent, MariadbGtidEvent, MariadbBinLogCheckPointEvent)
 from .exceptions import BinLogNotEnabled
 from .row_event import (
     UpdateRowsEvent, WriteRowsEvent, DeleteRowsEvent, TableMapEvent)
@@ -600,7 +600,8 @@ class BinLogStreamReader(object):
                 TableMapEvent,
                 HeartbeatLogEvent,
                 NotImplementedEvent,
-                MariadbGtidEvent
+                MariadbGtidEvent,
+                MariadbBinLogCheckPointEvent
                 ))
         if ignored_events is not None:
             for e in ignored_events:

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -119,13 +119,10 @@ class MariadbBinLogCheckPointEvent(BinLogEvent):
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
         super(MariadbBinLogCheckPointEvent, self).__init__(from_packet, event_size, table_map, ctl_connection,
                                                            **kwargs)
-
-        self.filename_length = self.packet.read_uint32()
-        self.filename = self.packet.read(event_size - 4).decode()
+        filename_length = self.packet.read_uint32()
+        self.filename = self.packet.read(filename_length).decode()
 
     def _dump(self):
-        super(MariadbBinLogCheckPointEvent, self)._dump()
-        print("Filename Length:", self.filename_length)
         print('Filename:', self.filename)
 
 class RotateEvent(BinLogEvent):

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -114,6 +114,10 @@ class MariadbBinLogCheckPointEvent(BinLogEvent):
     """
     Check point in binlog event in MariaDB
     https://mariadb.com/kb/en/binlog_checkpoint_event/
+
+    Attributes:
+        filename length: Length of filename
+        filename: Name of file saved in checkpoint
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -110,6 +110,23 @@ class MariadbGtidEvent(BinLogEvent):
         print("Flags:", self.flags)
         print('GTID:', self.gtid)
 
+class MariadbBinLogCheckPointEvent(BinLogEvent):
+    """
+    Check point in binlog event in MariaDB
+    https://mariadb.com/kb/en/binlog_checkpoint_event/
+    """
+
+    def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
+        super(MariadbBinLogCheckPointEvent, self).__init__(from_packet, event_size, table_map, ctl_connection,
+                                                           **kwargs)
+
+        self.filename_length = self.packet.read_uint32()
+        self.filename = self.packet.read(event_size - 4).decode()
+
+    def _dump(self):
+        super(MariadbBinLogCheckPointEvent, self)._dump()
+        print("Filename Length:", self.filename_length)
+        print('Filename:', self.filename)
 
 class RotateEvent(BinLogEvent):
     """Change MySQL bin log file

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -112,12 +112,13 @@ class MariadbGtidEvent(BinLogEvent):
 
 class MariadbBinLogCheckPointEvent(BinLogEvent):
     """
-    Represent a checkpoint in a binlog event in MariaDB.
+    Represents a checkpoint in a binlog event in MariaDB.
+
+    More details are available in the MariaDB Knowledge Base:
     https://mariadb.com/kb/en/binlog_checkpoint_event/
 
-    Attributes:
-        filename_length (int): The length of the filename.
-        filename (str): The name of the file saved at the checkpoint.
+    :ivar filename_length:  int - The length of the filename.
+    :ivar filename: str - The name of the file saved at the checkpoint.
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -112,12 +112,12 @@ class MariadbGtidEvent(BinLogEvent):
 
 class MariadbBinLogCheckPointEvent(BinLogEvent):
     """
-    Check point in binlog event in MariaDB
+    Represent a checkpoint in a binlog event in MariaDB.
     https://mariadb.com/kb/en/binlog_checkpoint_event/
 
     Attributes:
-        filename length: Length of filename
-        filename: Name of file saved in checkpoint
+        filename_length (int): The length of the filename.
+        filename (str): The name of the file saved at the checkpoint.
     """
 
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -84,7 +84,7 @@ class BinLogPacketWrapper(object):
         constants.PREVIOUS_GTIDS_LOG_EVENT: event.NotImplementedEvent,
         # MariaDB GTID
         constants.MARIADB_ANNOTATE_ROWS_EVENT: event.NotImplementedEvent,
-        constants.MARIADB_BINLOG_CHECKPOINT_EVENT: event.NotImplementedEvent,
+        constants.MARIADB_BINLOG_CHECKPOINT_EVENT: event.MariadbBinLogCheckPointEvent,
         constants.MARIADB_GTID_EVENT: event.MariadbGtidEvent,
         constants.MARIADB_GTID_GTID_LIST_EVENT: event.NotImplementedEvent,
         constants.MARIADB_START_ENCRYPTION_EVENT: event.NotImplementedEvent

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -121,3 +121,34 @@ class PyMySQLReplicationTestCase(base):
         bin_log_basename = cursor.fetchone()[0]
         bin_log_basename = bin_log_basename.split("/")[-1]
         return bin_log_basename
+
+
+class PyMySQLReplicationMariaDbTestCase(PyMySQLReplicationTestCase):
+    def setUp(self):
+        # default
+        self.database = {
+            "host": "localhost",
+            "user": "root",
+            "passwd": "",
+            "port": 3308,
+            "use_unicode": True,
+            "charset": "utf8",
+            "db": "pymysqlreplication_test"
+        }
+
+        self.conn_control = None
+        db = copy.copy(self.database)
+        db["db"] = None
+        self.connect_conn_control(db)
+        self.execute("DROP DATABASE IF EXISTS pymysqlreplication_test")
+        self.execute("CREATE DATABASE pymysqlreplication_test")
+        db = copy.copy(self.database)
+        self.connect_conn_control(db)
+        self.stream = None
+        self.resetBinLog()
+    
+    def bin_log_basename(self):
+        cursor = self.execute('select @@log_bin_basename')
+        bin_log_basename = cursor.fetchone()[0]
+        bin_log_basename = bin_log_basename.split("/")[-1]
+        return bin_log_basename

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -130,7 +130,7 @@ class PyMySQLReplicationMariaDbTestCase(PyMySQLReplicationTestCase):
             "host": "localhost",
             "user": "root",
             "passwd": "",
-            "port": 3308,
+            "port": 3306,
             "use_unicode": True,
             "charset": "utf8",
             "db": "pymysqlreplication_test"

--- a/pymysqlreplication/tests/base.py
+++ b/pymysqlreplication/tests/base.py
@@ -130,7 +130,7 @@ class PyMySQLReplicationMariaDbTestCase(PyMySQLReplicationTestCase):
             "host": "localhost",
             "user": "root",
             "passwd": "",
-            "port": 3306,
+            "port": 3308,
             "use_unicode": True,
             "charset": "utf8",
             "db": "pymysqlreplication_test"

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -17,7 +17,7 @@ from pymysqlreplication.exceptions import TableMetadataUnavailableError
 from pymysqlreplication.constants.BINLOG import *
 from pymysqlreplication.row_event import *
 
-__all__ = ["TestBasicBinLogStreamReader", "TestMultipleRowBinLogStreamReader", "TestCTLConnectionSettings", "TestGtidBinLogStreamReader"]
+__all__ = ["TestBasicBinLogStreamReader", "TestMultipleRowBinLogStreamReader", "TestCTLConnectionSettings", "TestGtidBinLogStreamReader", "TestMariadbBinlogStreamReader"]
 
 
 class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
@@ -25,9 +25,9 @@ class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
         return [GtidEvent]
 
     def test_allowed_event_list(self):
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 16)
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 15)
-        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 15)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 17)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 16)
+        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 16)
         self.assertEqual(len(self.stream._allowed_event_list([RotateEvent], None, False)), 1)
 
     def test_read_query_event(self):
@@ -1002,6 +1002,25 @@ class GtidTests(unittest.TestCase):
             gtid = Gtid("57b70f4e-20d3-11e5-a393-4a63946f7eac:1-:1")
             gtid = Gtid("57b70f4e-20d3-11e5-a393-4a63946f7eac::1")
 
+class TestMariadbBinlogStreamReader(base.PyMySQLReplicationMariaDbTestCase):
+
+    def test_binlog_checkpoint_event(self):
+
+        query = "CREATE TABLE test (id INT NOT NULL AUTO_INCREMENT, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))"
+        self.execute(query)
+
+        self.stream.close()
+        self.stream = BinLogStreamReader(
+            self.database, 
+            server_id=1024, 
+            blocking=False,
+            only_events=[MariadbBinLogCheckPointEvent],
+            is_mariadb=True
+            )
+
+        event = self.stream.fetchone()
+        self.assertIsInstance(event, MariadbBinLogCheckPointEvent)
+        self.assertEqual(event.filename, self.bin_log_basename() + ".000001")
 
 if __name__ == "__main__":
     import unittest

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -1003,35 +1003,31 @@ class GtidTests(unittest.TestCase):
             gtid = Gtid("57b70f4e-20d3-11e5-a393-4a63946f7eac::1")
 
 class TestMariadbBinlogStreamReader(base.PyMySQLReplicationMariaDbTestCase):
-
     def test_binlog_checkpoint_event(self):
-
         self.stream.close()
         self.stream = BinLogStreamReader(
             self.database, 
-            server_id=1024, 
+            server_id=1023,
             blocking=False,
             is_mariadb=True
-            )
+        )
 
         query = "DROP TABLE IF EXISTS test"
         self.execute(query)
 
         query = "CREATE TABLE test (id INT NOT NULL AUTO_INCREMENT, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))"
         self.execute(query)
+        self.stream.close()
 
-        #check rotate event
         event = self.stream.fetchone()
         self.assertIsInstance(event, RotateEvent)  
         
-        #check format description event
         event = self.stream.fetchone()
         self.assertIsInstance(event,FormatDescriptionEvent)
 
-        #check Mariadb binlog checkpoint event
         event = self.stream.fetchone()
         self.assertIsInstance(event, MariadbBinLogCheckPointEvent)
-        self.assertEqual(event.filename, self.bin_log_basename() + ".000001")
+        self.assertEqual(event.filename, self.bin_log_basename()+".000001")
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
Issue https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/issues/29

XA crash recovery가 시작될 binlog file을 지정하는 MARIADB_BINLOG_CHECKPOINT_EVENT를 구현합니다.
filename을 출력하도록 추가했습니다.
https://mariadb.com/kb/en/binlog_checkpoint_event/

@syeeuns 님이 오픈해주셨던 풀리퀘를 정리 후 다시 만들었습니다!