### PR TITLE
Add PreviousGtidsEvent

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -14,7 +14,8 @@ from .event import (
     QueryEvent, RotateEvent, FormatDescriptionEvent,
     XidEvent, GtidEvent, StopEvent, XAPrepareEvent,
     BeginLoadQueryEvent, ExecuteLoadQueryEvent,
-    HeartbeatLogEvent, NotImplementedEvent, MariadbGtidEvent)
+    HeartbeatLogEvent, NotImplementedEvent, MariadbGtidEvent,
+    PreviousGtidEvent)
 from .exceptions import BinLogNotEnabled
 from .row_event import (
     UpdateRowsEvent, WriteRowsEvent, DeleteRowsEvent, TableMapEvent)
@@ -600,7 +601,8 @@ class BinLogStreamReader(object):
                 TableMapEvent,
                 HeartbeatLogEvent,
                 NotImplementedEvent,
-                MariadbGtidEvent
+                MariadbGtidEvent,
+                PreviousGtidEvent
                 ))
         if ignored_events is not None:
             for e in ignored_events:

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -15,7 +15,7 @@ from .event import (
     XidEvent, GtidEvent, StopEvent, XAPrepareEvent,
     BeginLoadQueryEvent, ExecuteLoadQueryEvent,
     HeartbeatLogEvent, NotImplementedEvent, MariadbGtidEvent,
-    PreviousGtidEvent)
+    PreviousGtidsEvent)
 from .exceptions import BinLogNotEnabled
 from .row_event import (
     UpdateRowsEvent, WriteRowsEvent, DeleteRowsEvent, TableMapEvent)
@@ -602,7 +602,7 @@ class BinLogStreamReader(object):
                 HeartbeatLogEvent,
                 NotImplementedEvent,
                 MariadbGtidEvent,
-                PreviousGtidEvent
+                PreviousGtidsEvent
                 ))
         if ignored_events is not None:
             for e in ignored_events:

--- a/pymysqlreplication/event.py
+++ b/pymysqlreplication/event.py
@@ -90,7 +90,7 @@ class GtidEvent(BinLogEvent):
         return '<GtidEvent "%s">' % self.gtid
 
 
-class PreviousGtidEvent(BinLogEvent):
+class PreviousGtidsEvent(BinLogEvent):
     """
     PreviousGtidEvent is contains the Gtids executed in the last binary log file.
     Attributes:
@@ -100,7 +100,7 @@ class PreviousGtidEvent(BinLogEvent):
     Eg: [4c9e3dfc-9d25-11e9-8d2e-0242ac1cfd7e:1-100, 4c9e3dfc-9d25-11e9-8d2e-0242ac1cfd7e:1-10:20-30]
     """
     def __init__(self, from_packet, event_size, table_map, ctl_connection, **kwargs):
-        super(PreviousGtidEvent, self).__init__(from_packet, event_size, table_map,
+        super(PreviousGtidsEvent, self).__init__(from_packet, event_size, table_map,
                                                 ctl_connection, **kwargs)
 
         self._n_sid = self.packet.read_int64()
@@ -121,7 +121,7 @@ class PreviousGtidEvent(BinLogEvent):
         print("previous_gtids: %s" % self._previous_gtids)
 
     def __repr__(self):
-        return '<PreviousGtidEvent "%s">' % self._previous_gtids
+        return '<PreviousGtidsEvent "%s">' % self._previous_gtids
 
 
 class MariadbGtidEvent(BinLogEvent):

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -65,6 +65,7 @@ class BinLogPacketWrapper(object):
         constants.XID_EVENT: event.XidEvent,
         constants.INTVAR_EVENT: event.IntvarEvent,
         constants.GTID_LOG_EVENT: event.GtidEvent,
+        constants.PREVIOUS_GTIDS_LOG_EVENT: event.PreviousGtidEvent,
         constants.STOP_EVENT: event.StopEvent,
         constants.BEGIN_LOAD_QUERY_EVENT: event.BeginLoadQueryEvent,
         constants.EXECUTE_LOAD_QUERY_EVENT: event.ExecuteLoadQueryEvent,
@@ -81,7 +82,6 @@ class BinLogPacketWrapper(object):
 
         #5.6 GTID enabled replication events
         constants.ANONYMOUS_GTID_LOG_EVENT: event.NotImplementedEvent,
-        constants.PREVIOUS_GTIDS_LOG_EVENT: event.NotImplementedEvent,
         # MariaDB GTID
         constants.MARIADB_ANNOTATE_ROWS_EVENT: event.NotImplementedEvent,
         constants.MARIADB_BINLOG_CHECKPOINT_EVENT: event.NotImplementedEvent,

--- a/pymysqlreplication/packet.py
+++ b/pymysqlreplication/packet.py
@@ -65,7 +65,7 @@ class BinLogPacketWrapper(object):
         constants.XID_EVENT: event.XidEvent,
         constants.INTVAR_EVENT: event.IntvarEvent,
         constants.GTID_LOG_EVENT: event.GtidEvent,
-        constants.PREVIOUS_GTIDS_LOG_EVENT: event.PreviousGtidEvent,
+        constants.PREVIOUS_GTIDS_LOG_EVENT: event.PreviousGtidsEvent,
         constants.STOP_EVENT: event.StopEvent,
         constants.BEGIN_LOAD_QUERY_EVENT: event.BeginLoadQueryEvent,
         constants.EXECUTE_LOAD_QUERY_EVENT: event.ExecuteLoadQueryEvent,

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -22,7 +22,7 @@ __all__ = ["TestBasicBinLogStreamReader", "TestMultipleRowBinLogStreamReader", "
 
 class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
     def ignoredEvents(self):
-        return [GtidEvent, PreviousGtidEvent]
+        return [GtidEvent, PreviousGtidsEvent]
 
     def test_allowed_event_list(self):
         self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 17)
@@ -522,7 +522,7 @@ class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
 
 class TestMultipleRowBinLogStreamReader(base.PyMySQLReplicationTestCase):
     def ignoredEvents(self):
-        return [GtidEvent, PreviousGtidEvent]
+        return [GtidEvent, PreviousGtidsEvent]
 
     def test_insert_multiple_row_event(self):
         query = "CREATE TABLE test (id INT NOT NULL AUTO_INCREMENT, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))"
@@ -844,7 +844,7 @@ class TestGtidBinLogStreamReader(base.PyMySQLReplicationTestCase):
         query = "COMMIT;"
         self.execute(query)
 
-        self.assertIsInstance(self.stream.fetchone(), PreviousGtidEvent)
+        self.assertIsInstance(self.stream.fetchone(), PreviousGtidsEvent)
         firstevent = self.stream.fetchone()
         self.assertIsInstance(firstevent, GtidEvent)
 
@@ -894,7 +894,7 @@ class TestGtidBinLogStreamReader(base.PyMySQLReplicationTestCase):
 
         self.assertIsInstance(self.stream.fetchone(), RotateEvent)
         self.assertIsInstance(self.stream.fetchone(), FormatDescriptionEvent)
-        self.assertIsInstance(self.stream.fetchone(), PreviousGtidEvent)
+        self.assertIsInstance(self.stream.fetchone(), PreviousGtidsEvent)
         self.assertIsInstance(self.stream.fetchone(), GtidEvent)
         event = self.stream.fetchone()
 

--- a/pymysqlreplication/tests/test_basic.py
+++ b/pymysqlreplication/tests/test_basic.py
@@ -22,12 +22,12 @@ __all__ = ["TestBasicBinLogStreamReader", "TestMultipleRowBinLogStreamReader", "
 
 class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
     def ignoredEvents(self):
-        return [GtidEvent]
+        return [GtidEvent, PreviousGtidEvent]
 
     def test_allowed_event_list(self):
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 16)
-        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 15)
-        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 15)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, False)), 17)
+        self.assertEqual(len(self.stream._allowed_event_list(None, None, True)), 16)
+        self.assertEqual(len(self.stream._allowed_event_list(None, [RotateEvent], False)), 16)
         self.assertEqual(len(self.stream._allowed_event_list([RotateEvent], None, False)), 1)
 
     def test_read_query_event(self):
@@ -522,7 +522,7 @@ class TestBasicBinLogStreamReader(base.PyMySQLReplicationTestCase):
 
 class TestMultipleRowBinLogStreamReader(base.PyMySQLReplicationTestCase):
     def ignoredEvents(self):
-        return [GtidEvent]
+        return [GtidEvent, PreviousGtidEvent]
 
     def test_insert_multiple_row_event(self):
         query = "CREATE TABLE test (id INT NOT NULL AUTO_INCREMENT, data VARCHAR (50) NOT NULL, PRIMARY KEY (id))"
@@ -844,6 +844,7 @@ class TestGtidBinLogStreamReader(base.PyMySQLReplicationTestCase):
         query = "COMMIT;"
         self.execute(query)
 
+        self.assertIsInstance(self.stream.fetchone(), PreviousGtidEvent)
         firstevent = self.stream.fetchone()
         self.assertIsInstance(firstevent, GtidEvent)
 
@@ -893,6 +894,7 @@ class TestGtidBinLogStreamReader(base.PyMySQLReplicationTestCase):
 
         self.assertIsInstance(self.stream.fetchone(), RotateEvent)
         self.assertIsInstance(self.stream.fetchone(), FormatDescriptionEvent)
+        self.assertIsInstance(self.stream.fetchone(), PreviousGtidEvent)
         self.assertIsInstance(self.stream.fetchone(), GtidEvent)
         event = self.stream.fetchone()
 

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -32,7 +32,7 @@ def to_binary_dict(d):
 
 class TestDataType(base.PyMySQLReplicationTestCase):
     def ignoredEvents(self):
-        return [GtidEvent, PreviousGtidEvent]
+        return [GtidEvent, PreviousGtidsEvent]
 
     def create_and_insert_value(self, create_query, insert_query):
         self.execute(create_query)

--- a/pymysqlreplication/tests/test_data_type.py
+++ b/pymysqlreplication/tests/test_data_type.py
@@ -32,7 +32,7 @@ def to_binary_dict(d):
 
 class TestDataType(base.PyMySQLReplicationTestCase):
     def ignoredEvents(self):
-        return [GtidEvent]
+        return [GtidEvent, PreviousGtidEvent]
 
     def create_and_insert_value(self, create_query, insert_query):
         self.execute(create_query)


### PR DESCRIPTION
Issue https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/issues/12

- 마지막 binary log 파일에서 실행된 gtid_executed 를 기록하는 PreviousGtidsEvent 를 구현합니다.
- 참고 : [mysql source code docs - Previous_gtids_event](https://dev.mysql.com/doc/dev/mysql-server/latest/classbinary__log_1_1Previous__gtids__event.html)
- 작성에 도움이 된 자료 [link](https://github.com/jeremycole/mysql_binlog/blob/e4daeea4e1ee54a0d54b133ef50d1446b2444775/lib/mysql_binlog/binlog_event_parser.rb#L658)