### PR TITLE
Feature/changed mysql replication command

### DIFF
--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -166,9 +166,8 @@ class BinLogStreamReader(object):
             skip_to_timestamp: Ignore all events until reaching specified
                                timestamp.
             report_slave: Report slave in SHOW SLAVE HOSTS.
-            slave_uuid: slave_uuid: Report slave_uuid or replica_uuid in
-                                    SHOW SLAVE HOSTS or SHOW REPLICAS that
-                                    depends on MySQL version.
+            slave_uuid: Report slave_uuid or replica_uuid in SHOW SLAVE HOSTS(MySQL 8.0.21-) or
+                        SHOW REPLICAS(MySQL 8.0.22+) depends on your MySQL version.
             fail_on_table_metadata_unavailable: Should raise exception if we
                                                 can't get table information on
                                                 row_events

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -301,7 +301,8 @@ class BinLogStreamReader(object):
 
         if self.slave_uuid:
             cur = self._stream_connection.cursor()
-            cur.execute("set @slave_uuid= '%s'" % self.slave_uuid)
+            cur.execute("SET @slave_uuid = %s, @replica_uuid = %s",
+                        (str(self.slave_uuid), str(self.slave_uuid)))
             cur.close()
 
         if self.slave_heartbeat:

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -302,8 +302,7 @@ class BinLogStreamReader(object):
 
         if self.slave_uuid:
             cur = self._stream_connection.cursor()
-            cur.execute("SET @slave_uuid = %s, @replica_uuid = %s",
-                        (str(self.slave_uuid), str(self.slave_uuid)))
+            cur.execute("SET @slave_uuid = %s, @replica_uuid = %s", (self.slave_uuid, self.slave_uuid))
             cur.close()
 
         if self.slave_heartbeat:

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -166,7 +166,9 @@ class BinLogStreamReader(object):
             skip_to_timestamp: Ignore all events until reaching specified
                                timestamp.
             report_slave: Report slave in SHOW SLAVE HOSTS.
-            slave_uuid: Report slave_uuid in SHOW SLAVE HOSTS.
+            slave_uuid: slave_uuid: Report slave_uuid or replica_uuid in
+                                    SHOW SLAVE HOSTS or SHOW REPLICAS that
+                                    depends on MySQL version.
             fail_on_table_metadata_unavailable: Should raise exception if we
                                                 can't get table information on
                                                 row_events


### PR DESCRIPTION
# Issue
Issue: #10 

# Problem
Since the `SHOW SLAVE HOSTS` statement was deprecated from MySQL 8.0.22[1], the MySQL variable `slave_uuid` is also be deprecated.

# Solution
To ensure version compatibility, both the `replica_uuid` and `slave_uuid` variables will be set to the MySQL Server.

This approach aligns with what was done in go-mysql[2].

# Additional Consideration
It would be prudent to change the name of the `slave_uuid` attribute to `server_uuid`, as it encapsulates the meanings of both `slave_uuid` and `replica_uuid`.

---
[1] [SHOW SLAVE HOSTS | SHOW REPLICAS Statement (MySQL Docs)](https://dev.mysql.com/doc/refman/8.0/en/show-slave-hosts.html)  
[2] [Set slave_uuid and replica_uuid (go-mysql-org/go-mysql)](https://github.com/go-mysql-org/go-mysql/pull/656)