### PR TITLE
(deprecated) typing - 'gtid.py', 'exceptions.py', 'binlogstream.py'

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Featured
 
 [Streaming Changes in a Database with Amazon Kinesis](https://aws.amazon.com/blogs/database/streaming-changes-in-a-database-with-amazon-kinesis/) (by Emmanuel Espina, Amazon Web Services)
 
+
 Projects using this library
 ===========================
 
@@ -86,6 +87,7 @@ Projects using this library
 * MySQL to Kafka (https://github.com/scottpersinger/mysql-to-kafka/)
 * Aventri MySQL Monitor (https://github.com/aventri/mysql-monitor)
 * BitSwanPump: A real-time stream processor  (https://github.com/LibertyAces/BitSwanPump)
+* clickhouse-mysql-data-reader: https://github.com/Altinity/clickhouse-mysql-data-reader
 
 MySQL server settings
 =========================

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -283,7 +283,7 @@ class BinLogStreamReader(object):
         if not self.report_slave:
             return
 
-        packet: ByteString = self.report_slave.encoded(self.__server_id)
+        packet: bytes = self.report_slave.encoded(self.__server_id)
 
         if pymysql.__version__ < LooseVersion("0.6"):
             self._stream_connection.wfile.write(packet)
@@ -374,7 +374,7 @@ class BinLogStreamReader(object):
                 prelude += self.log_file.encode()
         else:
             if self.is_mariadb:
-                prelude: ByteString = self.__set_mariadb_settings()
+                prelude = self.__set_mariadb_settings()
             else:
                 # Format for mysql packet master_auto_position
                 #

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -39,7 +39,7 @@ class ReportSlave(object):
     """Represent the values that you may report when connecting as a slave
     to a master. SHOW SLAVE HOSTS related"""
 
-    def __init__(self, value: Union[str, tuple[str, str, str, int]]) -> None:
+    def __init__(self, value: Union[str, Tuple[str, str, str, int]]) -> None:
         """
         Attributes:
             value: string or tuple

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -5,7 +5,7 @@ from distutils.version import LooseVersion
 
 import pymysql
 from pymysql.constants.COMMAND import COM_BINLOG_DUMP, COM_REGISTER_SLAVE
-from pymysql.cursors import DictCursor
+from pymysql.cursors import DictCursor, Cursor
 
 from .constants.BINLOG import TABLE_MAP_EVENT, ROTATE_EVENT, FORMAT_DESCRIPTION_EVENT
 from .event import (
@@ -20,6 +20,8 @@ from .gtid import GtidSet
 from .packet import BinLogPacketWrapper
 from .row_event import (
     UpdateRowsEvent, WriteRowsEvent, DeleteRowsEvent, TableMapEvent)
+from typing import ByteString, Union, Optional, List, Tuple, Dict, Any, Iterator, FrozenSet, Type
+from pymysql.connections import Connection
 
 try:
     from pymysql.constants.COMMAND import COM_BINLOG_DUMP_GTID
@@ -37,25 +39,24 @@ class ReportSlave(object):
     """Represent the values that you may report when connecting as a slave
     to a master. SHOW SLAVE HOSTS related"""
 
-    hostname = ''
-    username = ''
-    password = ''
-    port = 0
-
-    def __init__(self, value):
+    def __init__(self, value: Union[str, tuple[str, str, str, int]]) -> None:
         """
         Attributes:
             value: string or tuple
                    if string, then it will be used hostname
                    if tuple it will be used as (hostname, user, password, port)
         """
+        self.hostname: str = ''
+        self.username: str = ''
+        self.password: str = ''
+        self.port: int = 0
 
         if isinstance(value, (tuple, list)):
             try:
-                self.hostname = value[0]
-                self.username = value[1]
-                self.password = value[2]
-                self.port = int(value[3])
+                self.hostname: str = value[0]
+                self.username: str = value[1]
+                self.password: str = value[2]
+                self.port: int = int(value[3])
             except IndexError:
                 pass
         elif isinstance(value, dict):
@@ -65,13 +66,13 @@ class ReportSlave(object):
                 except KeyError:
                     pass
         else:
-            self.hostname = value
+            self.hostname: Union[str, tuple] = value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<ReportSlave hostname=%s username=%s password=%s port=%d>' % \
             (self.hostname, self.username, self.password, self.port)
 
-    def encoded(self, server_id, master_id=0):
+    def encoded(self, server_id: int, master_id: int = 0) -> ByteString:
         """
         server_id: the slave server-id
         master_id: usually 0. Appears as "master id" in SHOW SLAVE HOSTS
@@ -90,23 +91,23 @@ class ReportSlave(object):
         # 4              replication rank
         # 4              master-id
 
-        lhostname = len(self.hostname.encode())
-        lusername = len(self.username.encode())
-        lpassword = len(self.password.encode())
+        lhostname: int = len(self.hostname.encode())
+        lusername: int = len(self.username.encode())
+        lpassword: int = len(self.password.encode())
 
-        packet_len = (1 +  # command
-                      4 +  # server-id
-                      1 +  # hostname length
-                      lhostname +
-                      1 +  # username length
-                      lusername +
-                      1 +  # password length
-                      lpassword +
-                      2 +  # slave mysql port
-                      4 +  # replication rank
-                      4)  # master-id
+        packet_len: int = (1 +  # command
+                           4 +  # server-id
+                           1 +  # hostname length
+                           lhostname +
+                           1 +  # username length
+                           lusername +
+                           1 +  # password length
+                           lpassword +
+                           2 +  # slave mysql port
+                           4 +  # replication rank
+                           4)  # master-id
 
-        MAX_STRING_LEN = 257  # one byte for length + 256 chars
+        MAX_STRING_LEN: int = 257  # one byte for length + 256 chars
 
         return (struct.pack('<i', packet_len) +
                 bytes(bytearray([COM_REGISTER_SLAVE])) +
@@ -125,24 +126,24 @@ class ReportSlave(object):
 class BinLogStreamReader(object):
     """Connect to replication stream and read event
     """
-    report_slave = None
+    report_slave: Optional[ReportSlave] = None
 
-    def __init__(self, connection_settings, server_id,
-                 ctl_connection_settings=None, resume_stream=False,
-                 blocking=False, only_events=None, log_file=None,
-                 log_pos=None, end_log_pos=None,
-                 filter_non_implemented_events=True,
-                 ignored_events=None, auto_position=None,
-                 only_tables=None, ignored_tables=None,
-                 only_schemas=None, ignored_schemas=None,
-                 freeze_schema=False, skip_to_timestamp=None,
-                 report_slave=None, slave_uuid=None,
-                 pymysql_wrapper=None,
-                 fail_on_table_metadata_unavailable=False,
-                 slave_heartbeat=None,
-                 is_mariadb=False,
-                 annotate_rows_event=False,
-                 ignore_decode_errors=False):
+    def __init__(self, connection_settings: Dict, server_id: int,
+                 ctl_connection_settings: Optional[Dict] = None, resume_stream: bool = False,
+                 blocking: bool = False, only_events: Optional[List[str]] = None, log_file: Optional[str] = None,
+                 log_pos: Optional[int] = None, end_log_pos: Optional[int] = None,
+                 filter_non_implemented_events: bool = True,
+                 ignored_events: Optional[List[str]] = None, auto_position: Optional[str] = None,
+                 only_tables: Optional[List[str]] = None, ignored_tables: Optional[List[str]] = None,
+                 only_schemas: Optional[List[str]] = None, ignored_schemas: Optional[List[str]] = None,
+                 freeze_schema: bool = False, skip_to_timestamp: Optional[float] = None,
+                 report_slave: Optional[ReportSlave] = None, slave_uuid: Optional[str] = None,
+                 pymysql_wrapper: Optional[Connection] = None,
+                 fail_on_table_metadata_unavailable: bool = False,
+                 slave_heartbeat: Optional[float] = None,
+                 is_mariadb: bool = False,
+                 annotate_rows_event: bool = False,
+                 ignore_decode_errors: bool = False) -> None:
         """
         Attributes:
             ctl_connection_settings: Connection settings for cluster holding
@@ -182,89 +183,89 @@ class BinLogStreamReader(object):
                     to point to Mariadb specific GTID.
             annotate_rows_event: Parameter value to enable annotate rows event in mariadb,
                     used with 'is_mariadb'
-            ignore_decode_errors: If true, any decode errors encountered 
+            ignore_decode_errors: If true, any decode errors encountered
                                   when reading column data will be ignored.
         """
 
-        self.__connection_settings = connection_settings
+        self.__connection_settings: Dict = connection_settings
         self.__connection_settings.setdefault("charset", "utf8")
 
-        self.__connected_stream = False
-        self.__connected_ctl = False
-        self.__resume_stream = resume_stream
-        self.__blocking = blocking
-        self._ctl_connection_settings = ctl_connection_settings
+        self.__connected_stream: bool = False
+        self.__connected_ctl: bool = False
+        self.__resume_stream: bool = resume_stream
+        self.__blocking: bool = blocking
+        self._ctl_connection_settings: Dict = ctl_connection_settings
         if ctl_connection_settings:
             self._ctl_connection_settings.setdefault("charset", "utf8")
 
-        self.__only_tables = only_tables
-        self.__ignored_tables = ignored_tables
-        self.__only_schemas = only_schemas
-        self.__ignored_schemas = ignored_schemas
-        self.__freeze_schema = freeze_schema
-        self.__allowed_events = self._allowed_event_list(
+        self.__only_tables: Optional[List[str]] = only_tables
+        self.__ignored_tables: Optional[List[str]] = ignored_tables
+        self.__only_schemas: Optional[List[str]] = only_schemas
+        self.__ignored_schemas: Optional[List[str]] = ignored_schemas
+        self.__freeze_schema: bool = freeze_schema
+        self.__allowed_events: FrozenSet[str] = self._allowed_event_list(
             only_events, ignored_events, filter_non_implemented_events)
-        self.__fail_on_table_metadata_unavailable = fail_on_table_metadata_unavailable
-        self.__ignore_decode_errors = ignore_decode_errors
+        self.__fail_on_table_metadata_unavailable: bool = fail_on_table_metadata_unavailable
+        self.__ignore_decode_errors: bool = ignore_decode_errors
 
         # We can't filter on packet level TABLE_MAP and rotate event because
         # we need them for handling other operations
-        self.__allowed_events_in_packet = frozenset(
+        self.__allowed_events_in_packet: FrozenSet[str] = frozenset(
             [TableMapEvent, RotateEvent]).union(self.__allowed_events)
 
-        self.__server_id = server_id
-        self.__use_checksum = False
+        self.__server_id: int = server_id
+        self.__use_checksum: bool = False
 
         # Store table meta information
-        self.table_map = {}
-        self.log_pos = log_pos
-        self.end_log_pos = end_log_pos
-        self.log_file = log_file
-        self.auto_position = auto_position
-        self.skip_to_timestamp = skip_to_timestamp
-        self.is_mariadb = is_mariadb
-        self.__annotate_rows_event = annotate_rows_event
+        self.table_map: Dict = {}
+        self.log_pos: Optional[int] = log_pos
+        self.end_log_pos: Optional[int] = end_log_pos
+        self.log_file: Optional[str] = log_file
+        self.auto_position: Optional[str] = auto_position
+        self.skip_to_timestamp: Optional[float] = skip_to_timestamp
+        self.is_mariadb: bool = is_mariadb
+        self.__annotate_rows_event: bool = annotate_rows_event
 
         if end_log_pos:
-            self.is_past_end_log_pos = False
+            self.is_past_end_log_pos: bool = False
 
         if report_slave:
-            self.report_slave = ReportSlave(report_slave)
-        self.slave_uuid = slave_uuid
-        self.slave_heartbeat = slave_heartbeat
+            self.report_slave: Optional[ReportSlave] = ReportSlave(report_slave)
+        self.slave_uuid: Optional[str] = slave_uuid
+        self.slave_heartbeat: Optional[float] = slave_heartbeat
 
         if pymysql_wrapper:
-            self.pymysql_wrapper = pymysql_wrapper
+            self.pymysql_wrapper: Optional[Connection] = pymysql_wrapper
         else:
-            self.pymysql_wrapper = pymysql.connect
-        self.mysql_version = (0, 0, 0)
+            self.pymysql_wrapper: Optional[Union[Connection, Type[Connection]]] = pymysql.connect
+        self.mysql_version: Tuple = (0, 0, 0)
 
-    def close(self):
+    def close(self) -> None:
         if self.__connected_stream:
             self._stream_connection.close()
-            self.__connected_stream = False
+            self.__connected_stream: bool = False
         if self.__connected_ctl:
             # break reference cycle between stream reader and underlying
             # mysql connection object
             self._ctl_connection._get_table_information = None
             self._ctl_connection.close()
-            self.__connected_ctl = False
+            self.__connected_ctl: bool = False
 
-    def __connect_to_ctl(self):
+    def __connect_to_ctl(self) -> None:
         if not self._ctl_connection_settings:
-            self._ctl_connection_settings = dict(self.__connection_settings)
+            self._ctl_connection_settings: Dict[str, Any] = dict(self.__connection_settings)
         self._ctl_connection_settings["db"] = "information_schema"
         self._ctl_connection_settings["cursorclass"] = DictCursor
         self._ctl_connection_settings["autocommit"] = True
-        self._ctl_connection = self.pymysql_wrapper(**self._ctl_connection_settings)
+        self._ctl_connection: Connection = self.pymysql_wrapper(**self._ctl_connection_settings)
         self._ctl_connection._get_table_information = self.__get_table_information
-        self.__connected_ctl = True
+        self.__connected_ctl: bool = True
 
-    def __checksum_enabled(self):
+    def __checksum_enabled(self) -> bool:
         """Return True if binlog-checksum = CRC32. Only for MySQL > 5.6"""
-        cur = self._stream_connection.cursor()
+        cur: Cursor = self._stream_connection.cursor()
         cur.execute("SHOW GLOBAL VARIABLES LIKE 'BINLOG_CHECKSUM'")
-        result = cur.fetchone()
+        result: Optional[Tuple[str, str]] = cur.fetchone()
         cur.close()
 
         if result is None:
@@ -274,11 +275,11 @@ class BinLogStreamReader(object):
             return False
         return True
 
-    def _register_slave(self):
+    def _register_slave(self) -> None:
         if not self.report_slave:
             return
 
-        packet = self.report_slave.encoded(self.__server_id)
+        packet: ByteString = self.report_slave.encoded(self.__server_id)
 
         if pymysql.__version__ < LooseVersion("0.6"):
             self._stream_connection.wfile.write(packet)
@@ -289,14 +290,14 @@ class BinLogStreamReader(object):
             self._stream_connection._next_seq_id = 1
             self._stream_connection._read_packet()
 
-    def __connect_to_stream(self):
+    def __connect_to_stream(self) -> None:
         # log_pos (4) -- position in the binlog-file to start the stream with
         # flags (2) BINLOG_DUMP_NON_BLOCK (0 or 1)
         # server_id (4) -- server id of this slave
         # log_file (string.EOF) -- filename of the binlog on the master
         self._stream_connection = self.pymysql_wrapper(**self.__connection_settings)
 
-        self.__use_checksum = self.__checksum_enabled()
+        self.__use_checksum: bool = self.__checksum_enabled()
 
         # If checksum is enabled we need to inform the server about the that
         # we support it
@@ -312,17 +313,17 @@ class BinLogStreamReader(object):
 
         if self.slave_heartbeat:
             # 4294967 is documented as the max value for heartbeats
-            net_timeout = float(self.__connection_settings.get('read_timeout',
+            net_timeout: float = float(self.__connection_settings.get('read_timeout',
                                                                4294967))
             # If heartbeat is too low, the connection will disconnect before,
             # this is also the behavior in mysql
-            heartbeat = float(min(net_timeout / 2., self.slave_heartbeat))
+            heartbeat: float = float(min(net_timeout / 2., self.slave_heartbeat))
             if heartbeat > 4294967:
                 heartbeat = 4294967
 
             # master_heartbeat_period is nanoseconds
-            heartbeat = int(heartbeat * 1000000000)
-            cur = self._stream_connection.cursor()
+            heartbeat: int = int(heartbeat * 1000000000)
+            cur: Cursor = self._stream_connection.cursor()
             cur.execute("SET @master_heartbeat_period= %d" % heartbeat)
             cur.close()
 
@@ -330,7 +331,7 @@ class BinLogStreamReader(object):
         # Mariadb, when it tries to replace GTID events with dummy ones. Given that this library understands GTID
         # events, setting the capability to 4 circumvents this error.
         # If the DB is mysql, this won't have any effect so no need to run this in a condition
-        cur = self._stream_connection.cursor()
+        cur: Cursor = self._stream_connection.cursor()
         cur.execute("SET @mariadb_slave_capability=4")
         cur.close()
 
@@ -343,15 +344,15 @@ class BinLogStreamReader(object):
                 # only when log_file and log_pos both provided, the position info is
                 # valid, if not, get the current position from master
                 if self.log_file is None or self.log_pos is None:
-                    cur = self._stream_connection.cursor()
+                    cur: Cursor = self._stream_connection.cursor()
                     cur.execute("SHOW MASTER STATUS")
-                    master_status = cur.fetchone()
+                    master_status: Optional[Tuple[str, int, ...]] = cur.fetchone()
                     if master_status is None:
                         raise BinLogNotEnabled()
                     self.log_file, self.log_pos = master_status[:2]
                     cur.close()
 
-                prelude = struct.pack('<i', len(self.log_file) + 11) \
+                prelude: ByteString = struct.pack('<i', len(self.log_file) + 11) \
                           + bytes(bytearray([COM_BINLOG_DUMP]))
 
                 if self.__resume_stream:
@@ -359,7 +360,7 @@ class BinLogStreamReader(object):
                 else:
                     prelude += struct.pack('<I', 4)
 
-                flags = 0
+                flags: int = 0
 
                 if not self.__blocking:
                     flags |= 0x01  # BINLOG_DUMP_NON_BLOCK
@@ -369,7 +370,7 @@ class BinLogStreamReader(object):
                 prelude += self.log_file.encode()
         else:
             if self.is_mariadb:
-                prelude = self.__set_mariadb_settings()
+                prelude: ByteString = self.__set_mariadb_settings()
             else:
                 # Format for mysql packet master_auto_position
                 #
@@ -406,20 +407,20 @@ class BinLogStreamReader(object):
                 # and have two intervals, 1-3 and 8-10, 1 is the start position of
                 # the first interval 3 is the stop position of the first interval.
 
-                gtid_set = GtidSet(self.auto_position)
-                encoded_data_size = gtid_set.encoded_length
+                gtid_set: GtidSet = GtidSet(self.auto_position)
+                encoded_data_size: int = gtid_set.encoded_length
 
-                header_size = (2 +  # binlog_flags
+                header_size: int = (2 +  # binlog_flags
                                4 +  # server_id
                                4 +  # binlog_name_info_size
                                4 +  # empty binlog name
                                8 +  # binlog_pos_info_size
                                4)  # encoded_data_size
 
-                prelude = b'' + struct.pack('<i', header_size + encoded_data_size) \
+                prelude: ByteString = b'' + struct.pack('<i', header_size + encoded_data_size) \
                           + bytes(bytearray([COM_BINLOG_DUMP_GTID]))
 
-                flags = 0
+                flags: int = 0
                 if not self.__blocking:
                     flags |= 0x01  # BINLOG_DUMP_NON_BLOCK
                 flags |= 0x04  # BINLOG_THROUGH_GTID
@@ -449,11 +450,11 @@ class BinLogStreamReader(object):
         else:
             self._stream_connection._write_bytes(prelude)
             self._stream_connection._next_seq_id = 1
-        self.__connected_stream = True
+        self.__connected_stream: bool = True
 
-    def __set_mariadb_settings(self):
+    def __set_mariadb_settings(self) -> ByteString:
         # https://mariadb.com/kb/en/5-slave-registration/
-        cur = self._stream_connection.cursor()
+        cur: Cursor = self._stream_connection.cursor()
         if self.auto_position != None:
             cur.execute("SET @slave_connect_state='%s'" % self.auto_position)
         cur.execute("SET @slave_gtid_strict_mode=1")
@@ -461,21 +462,21 @@ class BinLogStreamReader(object):
         cur.close()
 
         # https://mariadb.com/kb/en/com_binlog_dump/
-        header_size = (
+        header_size: int = (
                 4 +  # binlog pos
                 2 +  # binlog flags
                 4 +  # slave server_id,
                 4  # requested binlog file name , set it to empty
         )
 
-        prelude = struct.pack('<i', header_size) + bytes(bytearray([COM_BINLOG_DUMP]))
+        prelude: ByteString = struct.pack('<i', header_size) + bytes(bytearray([COM_BINLOG_DUMP]))
 
         # binlog pos
         prelude += struct.pack('<i', 4)
 
-        flags = 0
+        flags: int = 0
 
-        # Enable annotate rows event 
+        # Enable annotate rows event
         if self.__annotate_rows_event:
             flags |= 0x02  # BINLOG_SEND_ANNOTATE_ROWS_EVENT
 
@@ -493,7 +494,7 @@ class BinLogStreamReader(object):
 
         return prelude
 
-    def fetchone(self):
+    def fetchone(self) -> Union[BinLogPacketWrapper, None]:
         while True:
             if self.end_log_pos and self.is_past_end_log_pos:
                 return None
@@ -524,7 +525,7 @@ class BinLogStreamReader(object):
             if not pkt.is_ok_packet():
                 continue
 
-            binlog_event = BinLogPacketWrapper(pkt, self.table_map,
+            binlog_event: BinLogPacketWrapper = BinLogPacketWrapper(pkt, self.table_map,
                                                self._ctl_connection,
                                                self.mysql_version,
                                                self.__use_checksum,
@@ -549,7 +550,7 @@ class BinLogStreamReader(object):
                 # invalidates all our cached table id to schema mappings. This means we have to load them all
                 # again for each logfile which is potentially wasted effort but we can't really do much better
                 # without being broken in restart case
-                self.table_map = {}
+                self.table_map: Dict = {}
             elif binlog_event.log_pos:
                 self.log_pos = binlog_event.log_pos
 
@@ -599,8 +600,8 @@ class BinLogStreamReader(object):
 
             return binlog_event.event
 
-    def _allowed_event_list(self, only_events, ignored_events,
-                            filter_non_implemented_events):
+    def _allowed_event_list(self, only_events: Optional[List[str]], ignored_events: Optional[List[str]],
+                            filter_non_implemented_events: bool) -> FrozenSet[str]:
         if only_events is not None:
             events = set(only_events)
         else:
@@ -638,13 +639,13 @@ class BinLogStreamReader(object):
                 pass
         return frozenset(events)
 
-    def __get_table_information(self, schema, table):
+    def __get_table_information(self, schema: str, table: str) -> List[Dict[str, Any]]:
         for i in range(1, 3):
             try:
                 if not self.__connected_ctl:
                     self.__connect_to_ctl()
 
-                cur = self._ctl_connection.cursor()
+                cur: Cursor = self._ctl_connection.cursor()
                 cur.execute("""
                     SELECT
                         COLUMN_NAME, COLLATION_NAME, CHARACTER_SET_NAME,
@@ -655,7 +656,7 @@ class BinLogStreamReader(object):
                     WHERE
                         table_schema = %s AND table_name = %s
                     """, (schema, table))
-                result = sorted(cur.fetchall(), key=lambda x: x['ORDINAL_POSITION'])
+                result: List = sorted(cur.fetchall(), key=lambda x: x['ORDINAL_POSITION'])
                 cur.close()
 
                 return result
@@ -667,5 +668,5 @@ class BinLogStreamReader(object):
                 else:
                     raise error
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Union[BinLogPacketWrapper, None]]:
         return iter(self.fetchone, None)

--- a/pymysqlreplication/binlogstream.py
+++ b/pymysqlreplication/binlogstream.py
@@ -8,9 +8,10 @@ from pymysql.constants.COMMAND import COM_BINLOG_DUMP, COM_REGISTER_SLAVE
 from pymysql.cursors import Cursor, DictCursor
 from pymysql.connections import Connection, MysqlPacket
 
+from . import event
 from .constants.BINLOG import TABLE_MAP_EVENT, ROTATE_EVENT, FORMAT_DESCRIPTION_EVENT
 from .event import (
-    QueryEvent, RotateEvent, FormatDescriptionEvent,
+    BinLogEvent, QueryEvent, RotateEvent, FormatDescriptionEvent,
     XidEvent, GtidEvent, StopEvent, XAPrepareEvent,
     BeginLoadQueryEvent, ExecuteLoadQueryEvent,
     HeartbeatLogEvent, NotImplementedEvent, MariadbGtidEvent,
@@ -212,7 +213,7 @@ class BinLogStreamReader(object):
 
         # We can't filter on packet level TABLE_MAP and rotate event because
         # we need them for handling other operations
-        self.__allowed_events_in_packet: FrozenSet[str] = frozenset(
+        self.__allowed_events_in_packet: FrozenSet[Type[BinLogEvent]] = frozenset(
             [TableMapEvent, RotateEvent]).union(self.__allowed_events)
 
         self.__server_id: int = server_id

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -103,7 +103,7 @@ class RowsEvent(BinLogEvent):
         # See http://dev.mysql.com/doc/internals/en/rows-event.html
         null_bitmap = self.packet.read((BitCount(cols_bitmap) + 7) / 8)
 
-        nullBitmapIndex = 0
+        null_bitmap_index = 0
         nb_columns = len(self.columns)
         for i in range(0, nb_columns):
             column = self.columns[i]
@@ -112,116 +112,126 @@ class RowsEvent(BinLogEvent):
             zerofill = self.table_map[self.table_id].columns[i].zerofill
             fixed_binary_length = self.table_map[self.table_id].columns[i].fixed_binary_length
 
-            if BitGet(cols_bitmap, i) == 0:
-                values[name] = None
-                continue
+            values[name] = self.__read_values_name(column, null_bitmap, null_bitmap_index,
+                                                   cols_bitmap, unsigned, zerofill,
+                                                   fixed_binary_length, i)
 
-            if self._is_null(null_bitmap, nullBitmapIndex):
-                values[name] = None
-            elif column.type == FIELD_TYPE.TINY:
-                if unsigned:
-                    values[name] = struct.unpack("<B", self.packet.read(1))[0]
-                    if zerofill:
-                        values[name] = format(values[name], '03d')
-                else:
-                    values[name] = struct.unpack("<b", self.packet.read(1))[0]
-            elif column.type == FIELD_TYPE.SHORT:
-                if unsigned:
-                    values[name] = struct.unpack("<H", self.packet.read(2))[0]
-                    if zerofill:
-                        values[name] = format(values[name], '05d')
-                else:
-                    values[name] = struct.unpack("<h", self.packet.read(2))[0]
-            elif column.type == FIELD_TYPE.LONG:
-                if unsigned:
-                    values[name] = struct.unpack("<I", self.packet.read(4))[0]
-                    if zerofill:
-                        values[name] = format(values[name], '010d')
-                else:
-                    values[name] = struct.unpack("<i", self.packet.read(4))[0]
-            elif column.type == FIELD_TYPE.INT24:
-                if unsigned:
-                    values[name] = self.packet.read_uint24()
-                    if zerofill:
-                        values[name] = format(values[name], '08d')
-                else:
-                    values[name] = self.packet.read_int24()
-            elif column.type == FIELD_TYPE.FLOAT:
-                values[name] = struct.unpack("<f", self.packet.read(4))[0]
-            elif column.type == FIELD_TYPE.DOUBLE:
-                values[name] = struct.unpack("<d", self.packet.read(8))[0]
-            elif column.type == FIELD_TYPE.VARCHAR or \
-                    column.type == FIELD_TYPE.STRING:
-                if column.max_length > 255:
-                    values[name] = self.__read_string(2, column)
-                else:
-                    values[name] = self.__read_string(1, column)
-
-                if fixed_binary_length and len(values[name]) < fixed_binary_length:
-                    # Fixed-length binary fields are stored in the binlog
-                    # without trailing zeros and must be padded with zeros up
-                    # to the specified length at read time.
-                    nr_pad = fixed_binary_length - len(values[name])
-                    values[name] += b'\x00' * nr_pad
-
-            elif column.type == FIELD_TYPE.NEWDECIMAL:
-                values[name] = self.__read_new_decimal(column)
-            elif column.type == FIELD_TYPE.BLOB:
-                values[name] = self.__read_string(column.length_size, column)
-            elif column.type == FIELD_TYPE.DATETIME:
-                values[name] = self.__read_datetime()
-            elif column.type == FIELD_TYPE.TIME:
-                values[name] = self.__read_time()
-            elif column.type == FIELD_TYPE.DATE:
-                values[name] = self.__read_date()
-            elif column.type == FIELD_TYPE.TIMESTAMP:
-                values[name] = datetime.datetime.utcfromtimestamp(
-                    self.packet.read_uint32())
-
-            # For new date format:
-            elif column.type == FIELD_TYPE.DATETIME2:
-                values[name] = self.__read_datetime2(column)
-            elif column.type == FIELD_TYPE.TIME2:
-                values[name] = self.__read_time2(column)
-            elif column.type == FIELD_TYPE.TIMESTAMP2:
-                values[name] = self.__add_fsp_to_time(
-                    datetime.datetime.utcfromtimestamp(
-                        self.packet.read_int_be_by_size(4)), column)
-            elif column.type == FIELD_TYPE.LONGLONG:
-                if unsigned:
-                    values[name] = self.packet.read_uint64()
-                    if zerofill:
-                        values[name] = format(values[name], '020d')
-                else:
-                    values[name] = self.packet.read_int64()
-            elif column.type == FIELD_TYPE.YEAR:
-                values[name] = self.packet.read_uint8() + 1900
-            elif column.type == FIELD_TYPE.ENUM:
-                values[name] = column.enum_values[
-                    self.packet.read_uint_by_size(column.size)]
-            elif column.type == FIELD_TYPE.SET:
-                # We read set columns as a bitmap telling us which options
-                # are enabled
-                bit_mask = self.packet.read_uint_by_size(column.size)
-                values[name] = set(
-                    val for idx, val in enumerate(column.set_values)
-                    if bit_mask & 2 ** idx
-                ) or None
-
-            elif column.type == FIELD_TYPE.BIT:
-                values[name] = self.__read_bit(column)
-            elif column.type == FIELD_TYPE.GEOMETRY:
-                values[name] = self.packet.read_length_coded_pascal_string(
-                    column.length_size)
-            elif column.type == FIELD_TYPE.JSON:
-                values[name] = self.packet.read_binary_json(column.length_size)
-            else:
-                raise NotImplementedError("Unknown MySQL column type: %d" %
-                                          (column.type))
-
-            nullBitmapIndex += 1
+            if BitGet(cols_bitmap, i) != 0:
+                null_bitmap_index += 1
 
         return values
+
+    def __read_values_name(self, column, null_bitmap, null_bitmap_index, cols_bitmap, unsigned, zerofill,
+                           fixed_binary_length, i):
+
+        if BitGet(cols_bitmap, i) == 0:
+            return None
+
+        if self._is_null(null_bitmap, null_bitmap_index):
+            return None
+
+        if column.type == FIELD_TYPE.TINY:
+            if unsigned:
+                ret = struct.unpack("<B", self.packet.read(1))[0]
+                if zerofill:
+                    ret = format(ret, '03d')
+                return ret
+            else:
+                return struct.unpack("<b", self.packet.read(1))[0]
+        elif column.type == FIELD_TYPE.SHORT:
+            if unsigned:
+                ret = struct.unpack("<H", self.packet.read(2))[0]
+                if zerofill:
+                    ret = format(ret, '05d')
+                return ret
+            else:
+                return struct.unpack("<h", self.packet.read(2))[0]
+        elif column.type == FIELD_TYPE.LONG:
+            if unsigned:
+                ret = struct.unpack("<I", self.packet.read(4))[0]
+                if zerofill:
+                    ret = format(ret, '010d')
+                return ret
+            else:
+                return struct.unpack("<i", self.packet.read(4))[0]
+        elif column.type == FIELD_TYPE.INT24:
+            if unsigned:
+                ret = self.packet.read_uint24()
+                if zerofill:
+                    ret = format(ret, '08d')
+                return ret
+            else:
+                return self.packet.read_int24()
+        elif column.type == FIELD_TYPE.FLOAT:
+            return struct.unpack("<f", self.packet.read(4))[0]
+        elif column.type == FIELD_TYPE.DOUBLE:
+            return struct.unpack("<d", self.packet.read(8))[0]
+        elif column.type == FIELD_TYPE.VARCHAR or \
+                column.type == FIELD_TYPE.STRING:
+            ret = self.__read_string(2, column) if column.max_length > 255 else self.__read_string(1, column)
+
+            if fixed_binary_length and len(ret) < fixed_binary_length:
+                # Fixed-length binary fields are stored in the binlog
+                # without trailing zeros and must be padded with zeros up
+                # to the specified length at read time.
+                nr_pad = fixed_binary_length - len(ret)
+                ret += b'\x00' * nr_pad
+            return ret
+        elif column.type == FIELD_TYPE.NEWDECIMAL:
+            return self.__read_new_decimal(column)
+        elif column.type == FIELD_TYPE.BLOB:
+            return self.__read_string(column.length_size, column)
+        elif column.type == FIELD_TYPE.DATETIME:
+            return self.__read_datetime()
+        elif column.type == FIELD_TYPE.TIME:
+            return self.__read_time()
+        elif column.type == FIELD_TYPE.DATE:
+            return self.__read_date()
+        elif column.type == FIELD_TYPE.TIMESTAMP:
+            return datetime.datetime.fromtimestamp(
+                self.packet.read_uint32())
+
+        # For new date format:
+        elif column.type == FIELD_TYPE.DATETIME2:
+            return self.__read_datetime2(column)
+        elif column.type == FIELD_TYPE.TIME2:
+            return self.__read_time2(column)
+        elif column.type == FIELD_TYPE.TIMESTAMP2:
+            return self.__add_fsp_to_time(
+                datetime.datetime.fromtimestamp(
+                    self.packet.read_int_be_by_size(4)), column)
+        elif column.type == FIELD_TYPE.LONGLONG:
+            if unsigned:
+                ret = self.packet.read_uint64()
+                if zerofill:
+                    ret = format(ret, '020d')
+                return ret
+            else:
+                return self.packet.read_int64()
+        elif column.type == FIELD_TYPE.YEAR:
+            return self.packet.read_uint8() + 1900
+        elif column.type == FIELD_TYPE.ENUM:
+            return column.enum_values[
+                self.packet.read_uint_by_size(column.size)]
+        elif column.type == FIELD_TYPE.SET:
+            # We read set columns as a bitmap telling us which options
+            # are enabled
+            bit_mask = self.packet.read_uint_by_size(column.size)
+            return set(
+                val for idx, val in enumerate(column.set_values)
+                if bit_mask & 2 ** idx
+            ) or None
+
+        elif column.type == FIELD_TYPE.BIT:
+            return self.__read_bit(column)
+        elif column.type == FIELD_TYPE.GEOMETRY:
+            return self.packet.read_length_coded_pascal_string(
+                column.length_size)
+        elif column.type == FIELD_TYPE.JSON:
+            return self.packet.read_binary_json(column.length_size)
+        else:
+            raise NotImplementedError("Unknown MySQL column type: %d" %
+                                      (column.type))
 
     def __add_fsp_to_time(self, time, column):
         """Read and add the fractional part of time

--- a/pymysqlreplication/row_event.py
+++ b/pymysqlreplication/row_event.py
@@ -79,8 +79,9 @@ class RowsEvent(BinLogEvent):
         #Body
         self.number_of_columns = self.packet.read_length_coded_binary()
         self.columns = self.table_map[self.table_id].columns
+        column_schemas = self.table_map[self.table_id].column_schemas
 
-        if len(self.columns) == 0:  # could not read the table metadata, probably already dropped
+        if len(column_schemas) == 0:  # could not read the table metadata, probably already dropped
             self.complete = False
             if self._fail_on_table_metadata_unavailable:
                 raise TableMetadataUnavailableError(self.table)
@@ -624,7 +625,7 @@ class TableMapEvent(BinLogEvent):
 
         ordinal_pos_loc = 0
 
-        if len(self.column_schemas) != 0:
+        if self.column_count != 0:
             # Read columns meta data
             column_types = bytearray(self.packet.read(self.column_count))
             self.packet.read_length_coded_binary()


### PR DESCRIPTION
우선 지금까지 구현 완료된 gtid.py / exceptions.py / binlogstream.py 에 대한 PR 올립니다!

- gtid.py : https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/pull/76
- exceptions.py : https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/pull/74
- binlogstream.py : https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/pull/79
- packet.py (ing) : https://github.com/23-OSSCA-python-mysql-replication/python-mysql-replication/pull/73